### PR TITLE
Adding refresh control and error snackbar

### DIFF
--- a/CryptoChaser/Presentation/MainView/CCMainListViewController.swift
+++ b/CryptoChaser/Presentation/MainView/CCMainListViewController.swift
@@ -123,22 +123,26 @@ final class CCMainListViewController: UIViewController, UITableViewDataSource, U
             activityIndicator.startAnimating()
             do {
                 try await viewModel.fetchCoins()
-                activityIndicator.stopAnimating()
-                refreshControl.endRefreshing()
                 errorView.isHidden = true
                 tableView.isHidden = false
-                tableView.reloadData()
+                endRefreshing()
             } catch {
                 if viewModel.coins.isEmpty {
                     showErrorScreen()
                 } else {
                     presentNetworkErrorSnackbar()
-                    tableView.reloadData()
                 }
-                activityIndicator.stopAnimating()
-                refreshControl.endRefreshing()
+                endRefreshing()
             }
         }
+    }
+    
+    func endRefreshing() {
+        activityIndicator.stopAnimating()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.refreshControl.endRefreshing()
+        }
+        tableView.reloadData()
     }
     
     func presentNetworkErrorSnackbar() {

--- a/CryptoChaser/Presentation/Shared Views/SnackbarView.swift
+++ b/CryptoChaser/Presentation/Shared Views/SnackbarView.swift
@@ -1,0 +1,66 @@
+//
+//  SnackbarView.swift
+//  CryptoChaser
+//
+//  Created by Ernesto Sánchez Kuri on 21/05/25.
+//
+
+import Foundation
+import UIKit
+
+final class SnackbarView: UIView {
+    private let label = UILabel()
+    
+    init() {
+        super.init(frame: .zero)
+        backgroundColor = .darkGray
+        layer.cornerRadius = 8
+        alpha = 0.0
+        
+        label.textColor = .white
+        label.font = .systemFont(ofSize: 17, weight: .medium)
+        label.numberOfLines = 0
+        addSubview(label)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: topAnchor, constant: 12),
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -12)
+        ])
+    }
+    
+    func present(in view: UIView, message: String, duration: TimeInterval = 3) {
+        label.text = message
+        view.addSubview(self)
+        translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -16),
+            leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16)
+        ])
+        
+        UIView.animate(withDuration: 0.25) {
+            self.alpha = 1.0
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+            self.hide()
+        }
+    }
+    
+    func hide() {
+        UIView.animate(withDuration: 0.3) {
+            self.alpha = 0.0
+        } completion: { _ in
+            self.removeFromSuperview()
+        }
+
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}


### PR DESCRIPTION
In this PR I'm adding a UIRefreshControl that will be used when the user pulls to refresh.  Also I added a new snackbar to show network errors.

How to test:
- Open the app
- Pull to refresh

![Simulator Screen Recording - iPhone 16e - 2025-05-21 at 16 47 31](https://github.com/user-attachments/assets/293ad8ad-5fc4-46f8-bf6f-002ad8d70c63)

Network Error:

![Simulator Screen Recording - iPhone 16e - 2025-05-21 at 16 52 22](https://github.com/user-attachments/assets/3455c737-2791-424a-82cc-e01b6905d4dc)


