### PR TITLE
Replacing native AsyncImage with Custom one

### DIFF
--- a/CryptoChaser/Presentation/MainView/Cell/SwiftUI/CurrencyCell.swift
+++ b/CryptoChaser/Presentation/MainView/Cell/SwiftUI/CurrencyCell.swift
@@ -34,6 +34,7 @@ struct CurrencyCell: View {
                 .bold()
                 
         }
+        .id(viewModel.currencyIdentifier)
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .ignore)
         .accessibilityHidden(true)

--- a/CryptoChaser/Presentation/Shared Views/RemoteImageView.swift
+++ b/CryptoChaser/Presentation/Shared Views/RemoteImageView.swift
@@ -9,17 +9,29 @@ import SwiftUI
 
 struct RemoteImageView: View {
     let url: URL
+    @State private var image: UIImage?
+    @Environment(\.imageLoader) private var imageLoader
+    var largeSize: Bool = false
     
     var body: some View {
-        AsyncImage(url: url, content: { image in
-            image
-                .resizable()
-        }, placeholder: {
-            Image(systemName: "bitcoinsign.circle")
-                .resizable()
-        })
-        .scaledToFit()
-        .clipShape(Circle())
+        ZStack {
+            if let unwrappedImage = image {
+                Image(uiImage: unwrappedImage)
+                    .resizable()
+            } else {
+                ProgressView()
+            }
+        }.task {
+            await loadImage()
+        }
+    }
+    
+    func loadImage() async {
+        do {
+            image = try await imageLoader.fetch(url)
+        } catch {
+            print(error)
+        }
     }
 }
 

--- a/CryptoChaser/Shared/ImageLoader.swift
+++ b/CryptoChaser/Shared/ImageLoader.swift
@@ -1,0 +1,76 @@
+//
+//  ImageLoader.swift
+//  CryptoChaser
+//
+//  Created by Ernesto Sánchez Kuri on 22/05/25.
+//
+
+import Foundation
+import SwiftUI
+
+enum ImageLoaderError: Error {
+    case invalidData
+}
+
+actor ImageLoader {
+    private var cache: URLCache = .shared
+    private var images: [URLRequest: LoaderStatus] = [:]
+    
+    public func fetch(_ url: URL) async throws -> UIImage? {
+        return try await fetchCurrencyLogo(url: url)
+    }
+    
+    func fetchCurrencyLogo(url: URL) async throws -> UIImage? {
+        
+        let request = URLRequest(url: url)
+        if let existingData = cache.cachedResponse(for: request)?.data {
+            return UIImage(data: existingData)
+        }
+        
+        if let status = images[request] {
+            switch status {
+            case .fetched(let img):
+                return img
+            case .inProgress(let task):
+                return try await task.value
+            }
+        }
+        
+        
+        let task: Task<UIImage, Error> = Task {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let image = UIImage(data: data) else {
+                throw ImageLoaderError.invalidData
+            }
+            let cachedData = CachedURLResponse(response: response, data: data)
+            cache.storeCachedResponse(cachedData, for: request)
+            return image
+        }
+        
+        images[request] = .inProgress(task)
+        
+        let image = try await task.value
+        
+        images[request] = .fetched(image)
+        
+        return image
+    }
+    
+    
+    private enum LoaderStatus {
+        case inProgress(Task<UIImage, Error>)
+        case fetched(UIImage)
+    }
+}
+
+
+struct ImageLoaderKey: EnvironmentKey {
+    static let defaultValue = ImageLoader()
+}
+
+extension EnvironmentValues {
+    var imageLoader: ImageLoader {
+        get { self[ImageLoaderKey.self] }
+        set { self[ImageLoaderKey.self ] = newValue}
+    }
+}


### PR DESCRIPTION
In this PR I'm creating a better image solution that works better for SwiftUI views inside a table view.

The problem:

AsyncImage was rendering every time and there was a flicker that made the UI look bad.

Solution:
Implemented a custom ImageLoader using URLCache

Video
![Simulator Screen Recording - iPhone 16 Pro - 2025-05-22 at 14 45 58](https://github.com/user-attachments/assets/80fb2b9e-ea49-4e0f-bc12-d182ee759216)

